### PR TITLE
FIX: valid scans would report a success and an error every time

### DIFF
--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -121,7 +121,7 @@ public class BarcodeScanner extends Plugin {
                     //Log.d(LOG_TAG, "This should never happen");
                 }
                 this.success(new PluginResult(PluginResult.Status.OK, obj), this.callback);
-            } if (resultCode == Activity.RESULT_CANCELED) {
+            } else if (resultCode == Activity.RESULT_CANCELED) {
                 JSONObject obj = new JSONObject();
                 try {
                     obj.put(TEXT, "");


### PR DESCRIPTION
After scanning a barcode on Android, the javascript code is receiving both a success and an error callback.
