### PR TITLE
Update to work with Cordova Module Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following barcode types are currently supported:
 
 A full example could be:
 
-   var scanner = window.PhoneGap.require("cordova/plugin/BarcodeScanner");
+   var scanner = window.cordova.require("cordova/plugin/BarcodeScanner");
 
    scanner.scan(
       function (result) {
@@ -74,7 +74,7 @@ Supported encoding types:
 
 A full example could be:
 
-   var scanner = window.PhoneGap.require("cordova/plugin/BarcodeScanner");
+   var scanner = window.cordova.require("cordova/plugin/BarcodeScanner");
 
    scanner.encode(BarcodeScanner.Encode.TEXT_TYPE, "http://www.nytimes.com", function(success) {
   	        alert("encode success: " + success);

--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -7,7 +7,7 @@
  */
 
 
-PhoneGap.define("cordova/plugin/BarcodeScanner",
+cordova.define("cordova/plugin/BarcodeScanner",
     
     function (require, exports, module) {
 


### PR DESCRIPTION
Updated the plugin to use `cordova.define` rather than `PhoneGap.define` in accordance with the [Cordova Module Spec](https://github.com/phonegap/phonegap-plugins/wiki/Defining-Your-Cordova-Plugin-As-A-Cordova-Module). Also updated documentation to reflect the proper way to call the plugin.
