### PR TITLE
avoid calling other apps activity

### DIFF
--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -109,6 +109,8 @@ public class BarcodeScanner extends CordovaPlugin {
     public void scan() {
         Intent intentScan = new Intent(SCAN_INTENT);
         intentScan.addCategory(Intent.CATEGORY_DEFAULT);
+        // avoid calling other phonegap apps
+        intentScan.setPackage(this.cordova.getActivity().getApplicationContext().getPackageName());
 
         this.cordova.startActivityForResult((CordovaPlugin) this, intentScan, REQUEST_CODE);
     }
@@ -163,6 +165,8 @@ public class BarcodeScanner extends CordovaPlugin {
         Intent intentEncode = new Intent(ENCODE_INTENT);
         intentEncode.putExtra(ENCODE_TYPE, type);
         intentEncode.putExtra(ENCODE_DATA, data);
+        // avoid calling other phonegap apps
+        intentEncode.setPackage(this.cordova.getActivity().getApplicationContext().getPackageName());
 
         this.cordova.getActivity().startActivity(intentEncode);
     }


### PR DESCRIPTION
This should fix issues that occur when you have two different PhoneGap apps with different versions of the plugin (calling different version of the intent might crash the application).
