### PR TITLE
Fixes issue where camera was occassionally black in Windows 8

### DIFF
--- a/src/windows8/BarcodeScannerProxy.js
+++ b/src/windows8/BarcodeScannerProxy.js
@@ -48,6 +48,7 @@ module.exports = {
 
             captureSettings = new Windows.Media.Capture.MediaCaptureInitializationSettings();
             captureSettings.streamingCaptureMode = Windows.Media.Capture.StreamingCaptureMode.video;
+            captureSettings.photoCaptureSource = Windows.Media.Capture.PhotoCaptureSource.videoPreview;
         }
 
         /**


### PR DESCRIPTION
Without setting the photo capture source, it would occasionally go to the 'photo' mode which would cause the exposure to be extremely low in the camera.