### PR TITLE
Add scan options to intent on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ committed with an updated jar.
 
 ## Using the plugin ##
 The plugin creates the object `cordova/plugin/BarcodeScanner` with the method `scan(success, fail)`. 
+Some platforms like Android allow to add options as a third parameter:
+scan(success, fail, '{"SCAN_MODE":"QR_CODE_MODE"}') .
 
 The following barcode types are currently supported:
 ### Android

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.phonegap.plugins.barcodescanner"
-    version="2.0.1">
+    version="2.0.2">
 
     <name>BarcodeScanner</name>
     <description>You can use the BarcodeScanner plugin to scan different types of barcodes (using the device's camera) and get the metadata encoded in them for processing within your application.</description>

--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -96,7 +96,8 @@ public class BarcodeScanner extends CordovaPlugin {
                 return true;
             }
         } else if (action.equals(SCAN)) {
-            scan();
+            String options = args.optString(0);
+            scan(options);
         } else {
             return false;
         }
@@ -106,8 +107,24 @@ public class BarcodeScanner extends CordovaPlugin {
     /**
      * Starts an intent to scan and decode a barcode.
      */
-    public void scan() {
+    public void scan(String options) {
         Intent intentScan = new Intent(SCAN_INTENT);
+        if (options != null) {
+            Log.d(LOG_TAG, "SCAN OPTIONS " + options);
+            try {
+                JSONObject opts = new JSONObject(options);
+                String scanFormats = opts.optString("SCAN_FORMATS");
+                if (scanFormats != null) {
+                    intentScan.putExtra("SCAN_FORMATS", scanFormats);
+                }
+                String scanMode = opts.optString("SCAN_MODE");
+                if (scanMode != null) {
+                    intentScan.putExtra("SCAN_MODE", scanMode);
+                }
+            } catch(JSONException je) {
+                Log.e(LOG_TAG, "SCAN OPTIONS conversion failed", je);
+            }
+        }
         intentScan.addCategory(Intent.CATEGORY_DEFAULT);
         // avoid calling other phonegap apps
         intentScan.setPackage(this.cordova.getActivity().getApplicationContext().getPackageName());

--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -69,8 +69,9 @@
          *        cancelled : true/false, // Was canceled.
          *    }
          * @param {Function} errorCallback
+         * @param {String} options // stringified JSON {"SCAN_MODE":"QR_CODE_MODE"}
          */
-        BarcodeScanner.prototype.scan = function (successCallback, errorCallback) {
+        BarcodeScanner.prototype.scan = function (successCallback, errorCallback, options) {
             if (errorCallback == null) {
                 errorCallback = function () {
                 };
@@ -86,7 +87,7 @@
                 return;
             }
 
-            exec(successCallback, errorCallback, 'BarcodeScanner', 'scan', []);
+            exec(successCallback, errorCallback, 'BarcodeScanner', 'scan', [options]);
         };
 
         //-------------------------------------------------------------------


### PR DESCRIPTION
I think this should work but it seems that the scan intent ignores the extras. So feel free to ignore this PR. 
I would have debugged this more but inserting all the LibraryProject files into plugin.xml was to much work.
Would you mind to add a plugin-lib.xml which compiles all the zxing stuff instead of using the jar?

-Axel