### PR TITLE
added support for adding config parameter which is passed to barcode scanner activity

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -71,7 +71,7 @@
                 android:windowSoftInputMode="stateAlwaysHidden"
                 android:exported="false">
                 <intent-filter>
-                    <action android:name="com.phonegap.plugins.barcodescanner.SCAN"/>
+                    <action android:name="com.google.zxing.client.android.SCAN"/>
                     <category android:name="android.intent.category.DEFAULT"/>
                 </intent-filter>
             </activity>

--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -20,6 +20,8 @@ import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;
 
+import android.util.Log;
+
 /**
  * This calls out to the ZXing barcode reader and returns the result.
  *
@@ -35,7 +37,7 @@ public class BarcodeScanner extends CordovaPlugin {
     private static final String TEXT = "text";
     private static final String DATA = "data";
     private static final String TYPE = "type";
-    private static final String SCAN_INTENT = "com.phonegap.plugins.barcodescanner.SCAN";
+    private static final String SCAN_INTENT = "com.google.zxing.client.android.SCAN";
     private static final String ENCODE_DATA = "ENCODE_DATA";
     private static final String ENCODE_TYPE = "ENCODE_TYPE";
     private static final String ENCODE_INTENT = "com.phonegap.plugins.barcodescanner.ENCODE";
@@ -96,7 +98,7 @@ public class BarcodeScanner extends CordovaPlugin {
                 return true;
             }
         } else if (action.equals(SCAN)) {
-            scan();
+            scan(args);
         } else {
             return false;
         }
@@ -106,9 +108,48 @@ public class BarcodeScanner extends CordovaPlugin {
     /**
      * Starts an intent to scan and decode a barcode.
      */
-    public void scan() {
+    public void scan(JSONArray args) {
         Intent intentScan = new Intent(SCAN_INTENT);
         intentScan.addCategory(Intent.CATEGORY_DEFAULT);
+
+        // add config as intent extras
+        if(args.length() > 0) {
+
+            JSONObject obj;
+            JSONArray names;
+            String key;
+            Object value;
+
+            for(int i=0; i<args.length(); i++) {
+
+                try {
+                    obj = args.getJSONObject(i);
+                } catch(JSONException e) {
+                    Log.i("CordovaLog", e.getLocalizedMessage());
+                    continue;
+                }
+
+                names = obj.names();
+                for(int j=0; j<names.length(); j++) {
+                    try {
+                        key = names.getString(j);
+                        value = obj.get(key);
+
+                        if(value instanceof Integer) {
+                            intentScan.putExtra(key, (Integer)value);
+                        } else if(value instanceof String) {
+                            intentScan.putExtra(key, (String)value);
+                        }
+
+                    } catch(JSONException e) {
+                        Log.i("CordovaLog", e.getLocalizedMessage());
+                        continue;
+                    }
+                }
+            }
+
+        }
+
         // avoid calling other phonegap apps
         intentScan.setPackage(this.cordova.getActivity().getApplicationContext().getPackageName());
 

--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -70,7 +70,18 @@
          *    }
          * @param {Function} errorCallback
          */
-        BarcodeScanner.prototype.scan = function (successCallback, errorCallback) {
+        BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config) {
+
+            if(config instanceof Array) {
+                // do nothing
+            } else {
+                if(typeof(config) === 'object') {
+                    config = [ config ];
+                } else {
+                    config = [];
+                }
+            }
+
             if (errorCallback == null) {
                 errorCallback = function () {
                 };
@@ -86,7 +97,7 @@
                 return;
             }
 
-            exec(successCallback, errorCallback, 'BarcodeScanner', 'scan', []);
+            exec(successCallback, errorCallback, 'BarcodeScanner', 'scan', config);
         };
 
         //-------------------------------------------------------------------


### PR DESCRIPTION
Suggested solution to PR #238 

Replaces **com.phonegap.plugins.barcodescanner.SCAN** activity with **com.google.zxing.client.android.SCAN** and permits supplying configuration options to the android activity via Intents.

for example:
```javascript
var config = {
        SCAN_WIDTH: width,
        SCAN_HEIGHT: height
}
```

Where the keyname is set as the intent extra's name, and the value is likewise set as the value. This allows any supporting configuration to be supplied.