### PR TITLE
Fixed call to deprecated require("cordova/windows8/commandProxy") for…

### DIFF
--- a/src/windows8/BarcodeScannerProxy.js
+++ b/src/windows8/BarcodeScannerProxy.js
@@ -127,4 +127,4 @@ module.exports = {
         fail("Not implemented yet");
     }
 };
-require("cordova/windows8/commandProxy").add("BarcodeScanner", module.exports);
+require("cordova/exec/proxy").add("BarcodeScanner", module.exports);


### PR DESCRIPTION
… windows8